### PR TITLE
Support user selected delivery method instead of smtp config.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,9 @@ In your Capistrano config file (usually deploy.rb):
       :authentication => :plain 
     }
 
+    # Or just use sendmail:
+    #set :cap_gun_action_mailer_config, :sendmail
+
     # define the options for the actual emails that go out -- :recipients is the only required option
     set :cap_gun_email_envelope, { 
       :from => "project.deployer@example.com", # Note, don't use the form "Someone project.deploy@example.com" as it'll blow up with ActionMailer 2.3+

--- a/lib/cap_gun.rb
+++ b/lib/cap_gun.rb
@@ -47,10 +47,17 @@ module CapGun
   class Mailer < ActionMailer::Base
 
       def self.load_mailer_config(cap)
-       raise ArgumentError, "You must define ActionMailer settings in 'cap_gun_action_mailer_config'" unless cap.cap_gun_action_mailer_config
-       raise ArgumentError, "Need at least one recipient." if !cap.exists?(:cap_gun_email_envelope) || cap[:cap_gun_email_envelope][:recipients].blank?
+        raise ArgumentError, "Need at least one recipient." if !cap.exists?(:cap_gun_email_envelope) || cap[:cap_gun_email_envelope][:recipients].blank?
 
-       ActionMailer::Base.smtp_settings = cap.cap_gun_action_mailer_config
+        config = cap.fetch(:cap_gun_action_mailer_config, nil)
+
+        if config.is_a? Symbol
+          ActionMailer::Base.delivery_method = config
+
+        else
+          raise ArgumentError, "You must define ActionMailer settings in 'cap_gun_action_mailer_config'" unless config
+          ActionMailer::Base.smtp_settings = config
+        end
       end
       
       # Grab the options for emailing from capistrano[:cap_gun_email_envelope] (should be set in your deploy file)


### PR DESCRIPTION
This is mostly a convenient way to enable sendmail (instead of using
:address => "localhost" as config).

Also, when using sendmail directly there is no need for a :from address
since sendmail will use an appropriate one automatically (if configured
correctly).
